### PR TITLE
Update to requests 2.25.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ pendulum
 Flask==1.0.2
 Flask-Migrate==2.1.1
 Flask-SQLAlchemy==2.3.2
-requests==2.21.0
+requests==2.25.0
 raven[flask]


### PR DESCRIPTION
This is so that we can update to a version of urllib3
later where SNYK-PYTHON-URLLIB3-1014645 is fixed.