### PR TITLE
Update to Flask-SQLAlchemy 2.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pendulum
 Flask==1.0.2
 Flask-Migrate==2.1.1
-Flask-SQLAlchemy==2.3.2
+Flask-SQLAlchemy==2.5.1
 paho-mqtt==1.5.1
 requests==2.25.0
 raven[flask]


### PR DESCRIPTION
This is to avoid a `can't set attribute` error
that comes up due to an incompatible sqlalchemy
version that would get installed otherwise.